### PR TITLE
WOO-15 - Add free shipping via coupon

### DIFF
--- a/trunk/assets/inc/functions.php
+++ b/trunk/assets/inc/functions.php
@@ -211,7 +211,7 @@ function oneO_addWooOrder($orderData, $orderid)
       if ($prod->get_price() != ($product['price'])) {
         $args['subtotal'] = $prod->get_price();
         $args['total'] = ($product['total']);
-        $discount = ($product['price']) - $prod->get_price();
+        $discount = ($product['price'] - $prod->get_price()) * ((int)$product['qty'] ?? 1);
         $totalDiscount += $discount;
         $discount_string = "katalys.com discount";
         $order->add_coupon($discount_string, $discount, 0);
@@ -220,7 +220,7 @@ function oneO_addWooOrder($orderData, $orderid)
     }
   }
 
-  if ($totalDiscount > 0.00) {
+  if ($totalDiscount > 0.00 || $totalDiscount < 0.00) {
     $order->set_discount_total($totalDiscount);
   }
   addCouponFreeShippingInOrder($order);

--- a/trunk/katalys-shop.php
+++ b/trunk/katalys-shop.php
@@ -15,7 +15,10 @@ const OOMP_TEXT_DOMAIN = 'katalys-shop'; // filename for the plugin, should matc
 const OOMP_NAMESPACE = '1o-to-store-api'; // namespace for API endpoint
 const OOMP_PASETO_EXP = 'PT05M'; // Paseto Expiry time, use 'PT05M' for production, 'P01Y' for dev
 
-const KATALYS_COUPON_FREE_SHIPPING = '_KS_FREE_SHIPPING_KS_';
+/**
+ * @const string
+ */
+const KATALYS_COUPON_FREE_SHIPPING = 'KS_';
 
 define('OOMP_LOC_URL', plugins_url('assets', __FILE__)); // absolute URL path
 

--- a/trunk/katalys-shop.php
+++ b/trunk/katalys-shop.php
@@ -14,6 +14,9 @@ const OOMP_VER_NUM = '1.1.14'; // version, should match "Version:" above
 const OOMP_TEXT_DOMAIN = 'katalys-shop'; // filename for the plugin, should match "Text Domain:" above
 const OOMP_NAMESPACE = '1o-to-store-api'; // namespace for API endpoint
 const OOMP_PASETO_EXP = 'PT05M'; // Paseto Expiry time, use 'PT05M' for production, 'P01Y' for dev
+
+const KATALYS_COUPON_FREE_SHIPPING = '_KS_FREE_SHIPPING_KS_';
+
 define('OOMP_LOC_URL', plugins_url('assets', __FILE__)); // absolute URL path
 
 // If this file is called directly, abort
@@ -51,6 +54,8 @@ add_filter('manage_edit-shop_order_columns', function ($columns) {
   $columns['oneo_order_type'] = 'Katalys Order';
   return $columns;
 });
+
+validateCouponKatalys();
 
 /**
  * Add data to 1o Order Column on order list page.


### PR DESCRIPTION
Now if the client creates a coupon with code _KS_FREE_SHIPPING_KS_, WooCommerce will give Free shipping for Katalys. 

![image](https://github.com/katalys/woo-1o/assets/142460041/3e52acd0-a86a-41af-b1e7-184950c9883f)

I'm validating via the store too. The client can't apply the coupon _KS_FREE_SHIPPING_KS_.

![image](https://github.com/katalys/woo-1o/assets/142460041/860d46bf-f00c-491a-8994-eeac657b6fd1)
![image](https://github.com/katalys/woo-1o/assets/142460041/dd26d6a2-7eba-4ed7-a5e7-9879a11a42c9)

When we place the order, Woocommerce will show this:
![image](https://github.com/katalys/woo-1o/assets/142460041/57639bae-4f8c-44a3-bae8-c24d92c210a2)

